### PR TITLE
Specified PLUGIN_SRCS manually and disabled its automatic detection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 # PLUGIN_SRCS is space-delimited list of subdirectories containg a plugin project.
 # You can leave it empty for automatic detection based on directories containing a package.json file.
-PLUGIN_SRCS=
+PLUGIN_SRCS=zfs
 
 # For installing to a remote machine for testing with `make install-remote`
 REMOTE_TEST_HOST=192.168.207.11
@@ -53,7 +53,8 @@ BUILD_FLAGS=-- --minify false
 endif
 
 ifndef PLUGIN_SRCS
-PLUGIN_SRCS:=$(patsubst %/package.json,%,$(wildcard */package.json))
+# PLUGIN_SRCS:=$(patsubst %/package.json,%,$(wildcard */package.json))
+$(error PLUGIN_SRCS not set - please edit Makefile)
 endif
 
 OUTPUTS:=$(addsuffix /dist/index.html, $(PLUGIN_SRCS))


### PR DESCRIPTION
Hello everyone!

### Problems

I found the deb package of the [latest release 1.1.11](https://github.com/45Drives/cockpit-zfs/releases/tag/v1.1.11) was missed, so I did some debugging.


### Debugging
There were some error messages in the workflow log, but the workflow was not stopped.
```
echo 'export const pluginVersion = "1.1.11-1built_from_source";' > cockpit-zfs-1.1.11/src/version.js
/bin/sh: 1: cannot create cockpit-zfs-1.1.11/src/version.js: Directory nonexistent
make[1]: *** [Makefile:74: cockpit-zfs-1.1.11/src/version.js] Error 2
```

This comes from the following Makefile scripts:
https://github.com/45Drives/cockpit-zfs/blob/702a32b449e447c10c934c721c7557dd241c579a/Makefile#L73-L74

The `VERSION_FILES` is set here:
https://github.com/45Drives/cockpit-zfs/blob/702a32b449e447c10c934c721c7557dd241c579a/Makefile#L64

And the `PLUGIN_SRCS` is set empty manually here:
https://github.com/45Drives/cockpit-zfs/blob/702a32b449e447c10c934c721c7557dd241c579a/Makefile#L15-L17

And there is a automatic detection:
https://github.com/45Drives/cockpit-zfs/blob/702a32b449e447c10c934c721c7557dd241c579a/Makefile#L55-L57

However, the commit ad0d07e51e0f66716de8b90262f1795510b29b2a added a new `package.json` at the root folder of the repo, which caused the automatic detection to set `PLUGIN_SRCS` to the root directory of the repository. This leads to the problem.

### Solution
I follows the Makefile in [cockpit-file-sharing](https://github.com/45Drives/cockpit-file-sharing) and [cockpit-scheduler](https://github.com/45Drives/cockpit-scheduler) to specify `PLUGIN_SRCS` manually and disable the automatic detection.