### PR TITLE
Bugfix disk.find ref error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,9 +25,7 @@
             "sqlite3",
             "jq",
             "msmtp",
-            "python3-dateutil",
-            "python3-google-auth",
-            "python3-google-auth-oauthlib"
+            "python3-dateutil"
         ],
         "rocky_common": [
             "cockpit",
@@ -37,9 +35,7 @@
             "sqlite",
             "python3-dateutil",
             "jq",
-            "msmtp",
-            "python3-google-auth",
-            "python3-google-auth-oauthlib"
+            "msmtp"
         ]
     },
     "builds": [

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -49,14 +49,6 @@ make DESTDIR=%{buildroot} install
 %attr(0755,root,root) /opt/45drives/houston/notification_utils.py
 
 %post
-#pip3 install --upgrade pip
-#pip3 install --upgrade google-auth google-auth-oauthlib
-
-# Ensure SQLite jq msmtp are  installed
-#dnf install -y sqlite || true  
-#dnf install -y jq || true  
-#dnf install -y msmtp || true  
-
 
 # Ensure systemd reloads and starts the service after installation
 # Reload systemd to ensure unit files are recognized

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -49,13 +49,6 @@ make DESTDIR=%{buildroot} install
 %attr(0755,root,root) /opt/45drives/houston/notification_utils.py
 
 %post
-#pip3 install --upgrade pip
-#pip3 install --upgrade google-auth google-auth-oauthlib
-
-# Ensure SQLite jq msmtp are  installed
-#dnf install -y sqlite || true  
-#dnf install -y jq || true  
-#dnf install -y msmtp || true  
 
 
 # Ensure systemd reloads and starts the service after installation


### PR DESCRIPTION
Removes unused python3-oauth dependencies and fixes a ref destructuring bug in helpers>matchDiskByVdevOrPath func resulting in the error "Disks.find is not a function".