### PR TITLE
fix: wrap emailFromOAuth in array to prevent .join() error on recieve…

### DIFF
--- a/zfs/src/components/notification/EmailSetupModal.vue
+++ b/zfs/src/components/notification/EmailSetupModal.vue
@@ -793,7 +793,7 @@ async function oAuthBtn() {
                     // Prepare emailConfig for DBus call
                     authEmailConfig.value.email = emailFromOAuth;
                     authEmailConfig.value.oauthRefreshToken = refreshValue; // refresh_token
-                    authEmailConfig.value.recieversEmail = emailFromOAuth;
+                    authEmailConfig.value.recieversEmail = [emailFromOAuth];
                     authEmailConfig.value.authMethod = "oauth2";
                     authEmailConfig.value.oauthAccessToken = tokenValue;
                     authEmailConfig.value.tokenExpiry = expiry;


### PR DESCRIPTION
Title: fix: prevent .join() error on [recieversEmail](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after Gmail OAuth

Description:

Problem
After authenticating via Gmail OAuth, updating SMTP settings fails with:

authEmailConfig.value.recieverEmail.join is not a function

Root Cause
In the oAuthBtn callback in [EmailSetupModal.vue](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [recieversEmail](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was assigned the raw emailFromOAuth string:

Since [recieversEmail](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is typed as string[], the downstream .join(",") call in updateSMTPConfig fails because strings don't have a .join() method.

Fix
Wrapped emailFromOAuth in an array so [recieversEmail](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) remains a string[]:

Notes
The SMTP path is unaffected — receiver emails are always set via the emailChips watcher, which correctly assigns an array.
This bug only triggers when using the OAuth flow, not manual SMTP configuration.