### PR TITLE
fix: prevent make install from overwriting SELinux contexts on system directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # Automatic Houston Plugin Makefile
 # Copyright (C) 2022 Josh Boudreau <jboudreau@45drives.com>
-# 
+#
 # Automatic Houston Plugin Makefile is free software: you can redistribute it and/or modify it under the terms
 # of the GNU General Public License as published by the Free Software Foundation, either version 3
 # of the License, or (at your option) any later version.
-# 
+#
 # Automatic Houston Plugin Makefile is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 # without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along with Automatic Houston Plugin Makefile.
-# If not, see <https://www.gnu.org/licenses/>. 
+# If not, see <https://www.gnu.org/licenses/>.
 
 # PLUGIN_SRCS is space-delimited list of subdirectories containg a plugin project.
 PLUGIN_SRCS=zfs
@@ -113,7 +113,7 @@ plugin-install-% plugin-install-local-% plugin-install-remote-%:
 	@echo
 	@echo Copying files
 	@if test -z "$(SSH)"; then \
-		cp -af $*/dist/* $(DESTDIR)$(INSTALL_PREFIX)/$*$(INSTALL_SUFFIX); else \
+		cp -rf --no-preserve=context $*/dist/* $(DESTDIR)$(INSTALL_PREFIX)/$*$(INSTALL_SUFFIX); else \
 		rsync -avh $*/dist/* $(REMOTE_TEST_USER)@$(REMOTE_TEST_HOST):$(DESTDIR)$(INSTALL_PREFIX)/$*$(INSTALL_SUFFIX); \
 	fi
 	@echo -e $(call greentext,Done installing $*)
@@ -130,10 +130,10 @@ plugin-install-remote-% : SSH=ssh $(REMOTE_TEST_USER)@$(REMOTE_TEST_HOST)
 plugin-install-remote-% : REMOTE_TEST_HOME=$(shell ssh $(REMOTE_TEST_USER)@$(REMOTE_TEST_HOST) 'echo $$HOME')
 
 system-files-install:
-	-cp -af system_files/* $(DESTDIR)/
+	-cp -rf --no-preserve=context system_files/* $(DESTDIR)/
 
 system-files-install-local:
-	-cp -af system_files/* $(DESTDIR)/
+	-cp -rf --no-preserve=context system_files/* $(DESTDIR)/
 
 system-files-install-remote:
 	-rsync -avh system_files/* $(REMOTE_TEST_USER)@$(REMOTE_TEST_HOST):$(DESTDIR)/
@@ -161,7 +161,7 @@ help:
 	@echo '    make'
 	@echo
 	@echo 'installation:'
-	@echo '    make install [RESTART_COCKPIT=1]' 
+	@echo '    make install [RESTART_COCKPIT=1]'
 	@echo
 	@echo 'testing:'
 	@echo '    make install-local [RESTART_COCKPIT=1]'


### PR DESCRIPTION
`system_files/` contains subdirectories like `etc/`, `opt/`, etc. that get copied into the root filesystem by `make install`. When the repo is cloned under a user's home directory (e.g. `/home/you/`), these source directories inherit the `user_home_t` SELinux label.

`cp -af` (`--preserve=all`) copies that label onto the destination, so `cp -af system_files/etc /` overwrites `/etc`'s SELinux context from `etc_t` to `user_home_t`. This causes SELinux to deny access to `/etc` for all confined processes — `sudo`, `sshd`, `systemd-resolved`, `auditd` — effectively locking the user out of the system.

Replace `cp -af` with `cp -rf --no-preserve=context` in all three local install targets (`plugin-install-%`, `system-files-install`, `system-files-install-local`) so file contents are copied without carrying over SELinux labels from the source tree.

Fixes #27 

`make install` broke a fedora server 43 install I could painfully restore from an open ssh connection. This would happen with any directory that doesn't have the `etc_t` SELinux label — which is any directory outside of `/etc` itself. Cloning to `/opt`, `/tmp`, `/srv` would all have the same problem, just with different wrong labels (`usr_t`, `tmp_t`, `var_t`, etc.).