### PR TITLE
OAuth test email fails without saving config first

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -2,7 +2,7 @@ name: Build Packages
 on:
   push:
     branches: 
-      - oauth-test-email-without-save
+      - build
     tags:
       - 'v*.*.*'
 jobs:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -2,7 +2,7 @@ name: Build Packages
 on:
   push:
     branches: 
-      - zvol
+      - oauth-test-email-without-save
     tags:
       - 'v*.*.*'
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## zfs module 1.2.21-3
+## zfs module 1.2.22-1
 
-* making a release for zvol
+* building test package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## zfs module 1.2.21-2
+## zfs module 1.2.21-3
 
-* building test package with ui fix for zvol
+* making a release for zvol

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "title": "zfs module",
     "stable": false,
     "version": "1.2.21",
-    "build_number": "2",
+    "build_number": "3",
     "author": "Jordan Keough <jkeough@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-zfs-45d",
     "license": "GPL-3.0+",
@@ -83,7 +83,7 @@
     "changelog": {
         "urgency": "medium",
         "version": "1.2.21",
-        "build_number": "2",
+        "build_number": "3",
         "date": null,
         "packager": "Jordan Keough <jkeough@45drives.com>",
         "changes": []

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "name": "cockpit-zfs",
     "title": "zfs module",
     "stable": true,
-    "version": "1.2.21",
-    "build_number": "3",
+    "version": "1.2.22",
+    "build_number": "1",
     "author": "Jordan Keough <jkeough@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-zfs-45d",
     "license": "GPL-3.0+",
@@ -82,8 +82,8 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "1.2.21",
-        "build_number": "3",
+        "version": "1.2.22",
+        "build_number": "1",
         "date": null,
         "packager": "Jordan Keough <jkeough@45drives.com>",
         "changes": []

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "schema_version": "45D_AP_V2.0",
     "name": "cockpit-zfs",
     "title": "zfs module",
-    "stable": false,
+    "stable": true,
     "version": "1.2.21",
     "build_number": "3",
     "author": "Jordan Keough <jkeough@45drives.com>",

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.22-1bookworm) bookworm; urgency=medium
+
+  * building test package
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 22 Apr 2026 07:24:48 -0300
+
 cockpit-zfs (1.2.21-3bookworm) bookworm; urgency=medium
 
   * making a release for zvol

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.21-3bookworm) bookworm; urgency=medium
+
+  * making a release for zvol
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 01 Apr 2026 07:45:17 -0300
+
 cockpit-zfs (1.2.21-2bookworm) bookworm; urgency=medium
 
   * building test package with ui fix for zvol

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -68,6 +68,8 @@ fi
 
 
 %changelog
+* Wed Apr 01 2026 Rachit Hans <rhans@45drives.com> 1.2.21-3
+- making a release for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-2
 - building test package with ui fix for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-1

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -73,6 +73,8 @@ fi
 
 
 %changelog
+* Wed Apr 22 2026 Rachit Hans <rhans@45drives.com> 1.2.22-1
+- building test package
 * Wed Apr 01 2026 Rachit Hans <rhans@45drives.com> 1.2.21-3
 - making a release for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-2

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -61,6 +61,11 @@ if systemctl cat houston-zfs-storage-alert.service &>/dev/null; then
     systemctl start houston-zfs-storage-alert.service || true
 fi
 
+# Restart Houston D-Bus server to pick up updated code
+if systemctl cat houston-dbus.service &>/dev/null; then
+    systemctl restart houston-dbus.service || true
+fi
+
 # Optional: Restart zed if present (ZFS Event Daemon)
 if systemctl cat zed.service &>/dev/null; then
     systemctl restart zed || true

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -74,6 +74,8 @@ fi
 
 
 %changelog
+* Wed Apr 22 2026 Rachit Hans <rhans@45drives.com> 1.2.22-1
+- building test package
 * Wed Apr 01 2026 Rachit Hans <rhans@45drives.com> 1.2.21-3
 - making a release for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-2

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -62,6 +62,11 @@ if systemctl cat houston-zfs-storage-alert.service &>/dev/null; then
     systemctl start houston-zfs-storage-alert.service || true
 fi
 
+# Restart Houston D-Bus server to pick up updated code
+if systemctl cat houston-dbus.service &>/dev/null; then
+    systemctl restart houston-dbus.service || true
+fi
+
 # Optional: Restart zed if present (ZFS Event Daemon)
 if systemctl cat zed.service &>/dev/null; then
     systemctl restart zed || true

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -69,6 +69,8 @@ fi
 
 
 %changelog
+* Wed Apr 01 2026 Rachit Hans <rhans@45drives.com> 1.2.21-3
+- making a release for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-2
 - building test package with ui fix for zvol
 * Tue Mar 31 2026 Rachit Hans <rhans@45drives.com> 1.2.21-1

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.22-1focal) focal; urgency=medium
+
+  * building test package
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 22 Apr 2026 07:24:48 -0300
+
 cockpit-zfs (1.2.21-3focal) focal; urgency=medium
 
   * making a release for zvol

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.21-3focal) focal; urgency=medium
+
+  * making a release for zvol
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 01 Apr 2026 07:45:17 -0300
+
 cockpit-zfs (1.2.21-2focal) focal; urgency=medium
 
   * building test package with ui fix for zvol

--- a/packaging/ubuntu-focal/postinst
+++ b/packaging/ubuntu-focal/postinst
@@ -11,6 +11,9 @@ echo "[INFO] Enabling services..."
 systemctl enable --now houston-zfs-storage-alert.timer || true
 systemctl enable houston-zfs-storage-alert.service || true
 
+echo "[INFO] Restarting Houston D-Bus server..."
+systemctl restart houston-dbus.service || true
+
 echo "[INFO] Starting services..."
 # Restarting services safely, allowing them to fail without aborting script
 systemctl restart zed || true

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.21-3jammy) jammy; urgency=medium
+
+  * making a release for zvol
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 01 Apr 2026 07:45:17 -0300
+
 cockpit-zfs (1.2.21-2jammy) jammy; urgency=medium
 
   * building test package with ui fix for zvol

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.22-1jammy) jammy; urgency=medium
+
+  * building test package
+
+ -- Rachit Hans <rhans@45drives.com>  Wed, 22 Apr 2026 07:24:48 -0300
+
 cockpit-zfs (1.2.21-3jammy) jammy; urgency=medium
 
   * making a release for zvol

--- a/packaging/ubuntu-jammy/postinst
+++ b/packaging/ubuntu-jammy/postinst
@@ -11,6 +11,9 @@ echo "[INFO] Enabling services..."
 systemctl enable --now houston-zfs-storage-alert.timer || true
 systemctl enable houston-zfs-storage-alert.service || true
 
+echo "[INFO] Restarting Houston D-Bus server..."
+systemctl restart houston-dbus.service || true
+
 echo "[INFO] Starting services..."
 # Restarting services safely, allowing them to fail without aborting script
 systemctl restart zed || true

--- a/system_files/opt/45drives/houston/notification_utils.py
+++ b/system_files/opt/45drives/houston/notification_utils.py
@@ -207,6 +207,36 @@ import email.message
 
 def sendTestEmailViaGmailApi(config):
     try:
+        # Ensure OAuth token file exists before refreshing.
+        # When sending a test email without saving first, the token file
+        # may not exist yet, so we write it from the config passed in.
+        oauth_file_missing = (
+            not os.path.exists(MSMTP_OAUTH_JSON_PATH)
+            or os.stat(MSMTP_OAUTH_JSON_PATH).st_size == 0
+        )
+        if oauth_file_missing:
+            access_token_from_config = config.get("oauthAccessToken", "")
+            refresh_token_from_config = config.get("oauthRefreshToken", "")
+            email_from_config = config.get("email", "")
+            expiry_from_config = config.get("tokenExpiry", "")
+
+            if not refresh_token_from_config:
+                return {
+                    "success": False,
+                    "message": "❌ No OAuth credentials found. Please sign in with Gmail first."
+                }
+
+            oauth_data_init = {
+                "access_token": access_token_from_config,
+                "refresh_token": refresh_token_from_config,
+                "user_email": email_from_config,
+                "expiry": expiry_from_config
+            }
+            os.makedirs(os.path.dirname(MSMTP_OAUTH_JSON_PATH), exist_ok=True)
+            with open(MSMTP_OAUTH_JSON_PATH, "w") as f:
+                json.dump(oauth_data_init, f, indent=4)
+            os.chmod(MSMTP_OAUTH_JSON_PATH, 0o600)
+
         # Refresh token first
         if not os.path.exists(MSMTP_OAUTH_REFRESH_SCRIPT):
             return {


### PR DESCRIPTION
**Problem**
Sending a test email via Gmail OAuth without saving first crashed with JSONDecodeError — the token file was empty and the refresh script couldn't parse it.

**Changes**
[notification_utils.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Write OAuth credentials to the token file from the request config if the file is missing/empty, before running the refresh script

Packaging post-install scripts: Added systemctl restart houston-dbus.service so the D-Bus server picks up new code on