### PR TITLE
Fix/dbus polling leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## zfs module 1.2.27-1
+## zfs module 1.2.27-2
 
-* Testing package for dbus leaks fix
+* Updating testing package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## zfs module 1.2.26-1
+## zfs module 1.2.27-1
 
-* Updates Notification UI with full support for Cockpit-Alerts redirect
+* Testing package for dbus leaks fix

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "cockpit-zfs",
     "title": "zfs module",
     "stable": false,
-    "version": "1.2.26",
+    "version": "1.2.27",
     "build_number": "1",
     "author": "Jordan Keough <jkeough@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-zfs-45d",
@@ -85,7 +85,7 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "1.2.26",
+        "version": "1.2.27",
         "build_number": "1",
         "date": null,
         "packager": "Jordan Keough <jkeough@45drives.com>",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "schema_version": "45D_AP_V2.0",
     "name": "cockpit-zfs",
     "title": "zfs module",
-    "stable": true,
+    "stable": false,
     "version": "1.2.26",
     "build_number": "1",
     "author": "Jordan Keough <jkeough@45drives.com>",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "title": "zfs module",
     "stable": false,
     "version": "1.2.27",
-    "build_number": "1",
+    "build_number": "2",
     "author": "Jordan Keough <jkeough@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-zfs-45d",
     "license": "GPL-3.0+",
@@ -86,7 +86,7 @@
     "changelog": {
         "urgency": "medium",
         "version": "1.2.27",
-        "build_number": "1",
+        "build_number": "2",
         "date": null,
         "packager": "Jordan Keough <jkeough@45drives.com>",
         "changes": []

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-2bookworm) bookworm; urgency=medium
+
+  * Updating testing package
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 10:35:16 -0300
+
 cockpit-zfs (1.2.27-1bookworm) bookworm; urgency=medium
 
   * Testing package for dbus leaks fix

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-1bookworm) bookworm; urgency=medium
+
+  * Testing package for dbus leaks fix
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 07:01:18 -0300
+
 cockpit-zfs (1.2.26-1bookworm) bookworm; urgency=medium
 
   * Updates Notification UI with full support for Cockpit-Alerts redirect

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -59,6 +59,8 @@ fi
 
 
 %changelog
+* Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-1
+- Testing package for dbus leaks fix
 * Thu Apr 30 2026 Jordan Keough <jkeough@45drives.com> 1.2.26-1
 - Updates Notification UI with full support for Cockpit-Alerts redirect
 * Mon Apr 27 2026 Jordan Keough <jkeough@45drives.com> 1.2.25-1

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -59,6 +59,8 @@ fi
 
 
 %changelog
+* Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-2
+- Updating testing package
 * Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-1
 - Testing package for dbus leaks fix
 * Thu Apr 30 2026 Jordan Keough <jkeough@45drives.com> 1.2.26-1

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -59,6 +59,8 @@ fi
 
 
 %changelog
+* Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-1
+- Testing package for dbus leaks fix
 * Thu Apr 30 2026 Jordan Keough <jkeough@45drives.com> 1.2.26-1
 - Updates Notification UI with full support for Cockpit-Alerts redirect
 * Mon Apr 27 2026 Jordan Keough <jkeough@45drives.com> 1.2.25-1

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -59,6 +59,8 @@ fi
 
 
 %changelog
+* Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-2
+- Updating testing package
 * Thu May 14 2026 Jordan Keough <jkeough@45drives.com> 1.2.27-1
 - Testing package for dbus leaks fix
 * Thu Apr 30 2026 Jordan Keough <jkeough@45drives.com> 1.2.26-1

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-2focal) focal; urgency=medium
+
+  * Updating testing package
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 10:35:16 -0300
+
 cockpit-zfs (1.2.27-1focal) focal; urgency=medium
 
   * Testing package for dbus leaks fix

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-1focal) focal; urgency=medium
+
+  * Testing package for dbus leaks fix
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 07:01:18 -0300
+
 cockpit-zfs (1.2.26-1focal) focal; urgency=medium
 
   * Updates Notification UI with full support for Cockpit-Alerts redirect

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-1jammy) jammy; urgency=medium
+
+  * Testing package for dbus leaks fix
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 07:01:18 -0300
+
 cockpit-zfs (1.2.26-1jammy) jammy; urgency=medium
 
   * Updates Notification UI with full support for Cockpit-Alerts redirect

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,9 @@
+cockpit-zfs (1.2.27-2jammy) jammy; urgency=medium
+
+  * Updating testing package
+
+ -- Jordan Keough <jkeough@45drives.com>  Thu, 14 May 2026 10:35:16 -0300
+
 cockpit-zfs (1.2.27-1jammy) jammy; urgency=medium
 
   * Testing package for dbus leaks fix

--- a/zfs/env.d.ts
+++ b/zfs/env.d.ts
@@ -1,2 +1,3 @@
 // /// <reference types="vite/client" />
+/// <reference path="../houston-common/cockpit-typings/cockpit-import-hack.d.ts" />
 declare const __APP_VERSION__: string;

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -193,7 +193,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, Ref, computed, ComputedRef, onMounted, watch } from "vue";
+import { ref, inject, Ref, computed, ComputedRef, onMounted, onBeforeUnmount, watch } from "vue";
 import { convertBytesToSize, convertSecondsToString, convertRawTimestampToString, upperCaseWord, convertTimestampToLocal, findMatchingPoolDisk } from "../../composables/helpers";
 import { loadScanObjectGroup, loadDiskStats } from "../../composables/loadData";
 import { ZPool, VDevDisk } from "@45drives/houston-common-lib";
@@ -290,26 +290,33 @@ async function setScanActivity(activity: Activity) {
 }
 
 const scanning = ref(false);
+let scanPollInFlight = false;
 
 async function scanNow() {
 	await loadScanObjectGroup(scanObjectGroup);
 }
 
 async function pollScanStatus() {
-	await scanNow();
+	if (scanPollInFlight) return;
+	scanPollInFlight = true;
+	try {
+		await scanNow();
 
-	const act = scanActivity.value;
-	if (!act) {
-		scanning.value = false;
-		return;
-	}
+		const act = scanActivity.value;
+		if (!act) {
+			scanning.value = false;
+			return;
+		}
 
-	await setScanActivity(act);
+		await setScanActivity(act);
 
-	if (act.isActive) {
-		scanning.value = !act.isPaused;
-	} else {
-		scanning.value = false;
+		if (act.isActive) {
+			scanning.value = !act.isPaused;
+		} else {
+			scanning.value = false;
+		}
+	} finally {
+		scanPollInFlight = false;
 	}
 }
 
@@ -487,6 +494,7 @@ async function setTrimActivity(activity: Activity) {
 }
 
 const checkingDiskStats = ref(false);
+let trimPollInFlight = false;
 
 async function checkDiskStats() {
 	await loadDiskStats(poolDiskStats);
@@ -501,27 +509,33 @@ function checkActivityState(activity: Activity) {
 }
 
 async function pollTrimStatus() {
-	await checkDiskStats();
+	if (trimPollInFlight) return;
+	trimPollInFlight = true;
+	try {
+		await checkDiskStats();
 
-	const act = trimActivity.value;
-	if (!act) {
-		checkingDiskStats.value = false;
-		return;
-	}
-
-	await setTrimActivity(act);
-
-	switch (checkActivityState(act)) {
-		case "active":
-			checkingDiskStats.value = true;
-			break;
-		case "paused":
-		case "canceled":
-		case "finished":
+		const act = trimActivity.value;
+		if (!act) {
 			checkingDiskStats.value = false;
-			break;
-		default:
-			break;
+			return;
+		}
+
+		await setTrimActivity(act);
+
+		switch (checkActivityState(act)) {
+			case "active":
+				checkingDiskStats.value = true;
+				break;
+			case "paused":
+			case "canceled":
+			case "finished":
+				checkingDiskStats.value = false;
+				break;
+			default:
+				break;
+		}
+	} finally {
+		trimPollInFlight = false;
 	}
 }
 
@@ -649,6 +663,11 @@ function trimProgressBarClass(disk: any) {
 onMounted(() => {
 	pollScanStatus();
 	pollTrimStatus();
+});
+
+onBeforeUnmount(() => {
+	stopScanInterval();
+	stopDiskStatsInterval();
 });
 
 defineExpose({

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -291,6 +291,8 @@ async function setScanActivity(activity: Activity) {
 
 const scanning = ref(false);
 let scanPollInFlight = false;
+// Per-instance handle so we only clear the shared ref if WE own it
+let ownScanIntervalId: ReturnType<typeof setInterval> | null = null;
 
 async function scanNow() {
 	await loadScanObjectGroup(scanObjectGroup);
@@ -322,14 +324,19 @@ async function pollScanStatus() {
 
 function startScanInterval() {
 	if (!scanIntervalID.value) {
-		scanIntervalID.value = setInterval(pollScanStatus, 3000);
+		ownScanIntervalId = setInterval(pollScanStatus, 3000);
+		scanIntervalID.value = ownScanIntervalId;
 	}
 }
 
 function stopScanInterval() {
-	if (scanIntervalID.value) {
-		clearInterval(scanIntervalID.value);
-		scanIntervalID.value = null;
+	// Only clear the shared ref if this instance owns it
+	if (ownScanIntervalId) {
+		clearInterval(ownScanIntervalId);
+		if (scanIntervalID.value === ownScanIntervalId) {
+			scanIntervalID.value = null;
+		}
+		ownScanIntervalId = null;
 	}
 }
 
@@ -495,6 +502,8 @@ async function setTrimActivity(activity: Activity) {
 
 const checkingDiskStats = ref(false);
 let trimPollInFlight = false;
+// Per-instance handle so we only clear the shared ref if WE own it
+let ownTrimIntervalId: ReturnType<typeof setInterval> | null = null;
 
 async function checkDiskStats() {
 	await loadDiskStats(poolDiskStats);
@@ -541,14 +550,19 @@ async function pollTrimStatus() {
 
 function startDiskStatsInterval() {
 	if (!diskStatsIntervalID.value) {
-		diskStatsIntervalID.value = setInterval(pollTrimStatus, 3000);
+		ownTrimIntervalId = setInterval(pollTrimStatus, 3000);
+		diskStatsIntervalID.value = ownTrimIntervalId;
 	}
 }
 
 function stopDiskStatsInterval() {
-	if (diskStatsIntervalID.value) {
-		clearInterval(diskStatsIntervalID.value);
-		diskStatsIntervalID.value = null;
+	// Only clear the shared ref if this instance owns it
+	if (ownTrimIntervalId) {
+		clearInterval(ownTrimIntervalId);
+		if (diskStatsIntervalID.value === ownTrimIntervalId) {
+			diskStatsIntervalID.value = null;
+		}
+		ownTrimIntervalId = null;
 	}
 }
 

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -299,11 +299,12 @@ async function scanNow() {
 
 // Derive local scan state from the shared scan data (called reactively + on-demand)
 function deriveScanState() {
-	const act = scanActivity.value;
-	if (!act) {
+	const actRef = scanActivity.value;
+	if (!actRef) {
 		scanning.value = false;
 		return;
 	}
+	const act = actRef.value;
 	// Inline getScanComputedProps + setScanActivity (synchronous)
 	isScanning.value = getScanStateBool("SCANNING").value;
 	isFinished.value = getScanStateBool("FINISHED").value;
@@ -515,11 +516,12 @@ function checkActivityState(activity: Activity) {
 
 // Derive local trim state from the shared disk-stats data
 function deriveTrimState() {
-	const act = trimActivity.value;
-	if (!act) {
+	const actRef = trimActivity.value;
+	if (!actRef) {
 		checkingDiskStats.value = false;
 		return;
 	}
+	const act = actRef.value;
 	// Inline setTrimActivity (synchronous — computed refs already updated)
 	act.isActive = isTrimActive.value;
 	act.isPaused = isTrimSuspended.value;

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -290,7 +290,6 @@ async function setScanActivity(activity: Activity) {
 }
 
 const scanning = ref(false);
-let scanPollInFlight = false;
 const scanSubscribers = inject<Ref<number>>('scan-subscribers')!;
 let scanSubscribed = false;
 
@@ -298,59 +297,51 @@ async function scanNow() {
 	await loadScanObjectGroup(scanObjectGroup);
 }
 
-async function pollScanStatus() {
-	if (scanPollInFlight) return;
-	scanPollInFlight = true;
-	try {
-		await scanNow();
-
-		const act = scanActivity.value;
-		if (!act) {
-			scanning.value = false;
-			return;
-		}
-
-		await setScanActivity(act);
-
-		if (act.isActive) {
-			scanning.value = !act.isPaused;
-		} else {
-			scanning.value = false;
-		}
-	} finally {
-		scanPollInFlight = false;
+// Derive local scan state from the shared scan data (called reactively + on-demand)
+function deriveScanState() {
+	const act = scanActivity.value;
+	if (!act) {
+		scanning.value = false;
+		return;
 	}
+	// Inline getScanComputedProps + setScanActivity (synchronous)
+	isScanning.value = getScanStateBool("SCANNING").value;
+	isFinished.value = getScanStateBool("FINISHED").value;
+	isCanceled.value = getScanStateBool("CANCELED").value;
+	isPaused.value = getScanPauseBool("None").value;
+	act.isActive = isScanning.value;
+	act.isPaused = isPaused.value;
+	act.isFinished = isFinished.value;
+	act.isCanceled = isCanceled.value;
+	scanning.value = act.isActive && !act.isPaused;
 }
 
-function subscribeScanInterval() {
+// React to shared scan data updates (provider refreshes scanObjectGroup periodically)
+watch(poolScan, deriveScanState, { deep: true });
+
+// One-shot refresh for exposed callers (e.g. after starting a scrub)
+async function pollScanStatus() {
+	await scanNow();
+	deriveScanState();
+}
+
+function subscribeScan() {
 	if (scanSubscribed) return;
 	scanSubscribed = true;
 	scanSubscribers.value++;
-	if (scanSubscribers.value === 1) {
-		// First subscriber starts the single shared interval
-		scanIntervalID.value = setInterval(pollScanStatus, 3000);
-	}
 }
 
-function unsubscribeScanInterval() {
+function unsubscribeScan() {
 	if (!scanSubscribed) return;
 	scanSubscribed = false;
-	scanSubscribers.value--;
-	if (scanSubscribers.value <= 0) {
-		// Last subscriber stops the shared interval
-		scanSubscribers.value = 0;
-		if (scanIntervalID.value) {
-			clearInterval(scanIntervalID.value);
-			scanIntervalID.value = null;
-		}
-	}
+	scanSubscribers.value = Math.max(0, scanSubscribers.value - 1);
 }
 
 watch(
 	scanning,
 	() => {
-		if (scanning.value) subscribeScanInterval();
-		else unsubscribeScanInterval();
+		if (scanning.value) subscribeScan();
+		else unsubscribeScan();
 	},
 	{ immediate: true }
 );
@@ -523,64 +514,59 @@ function checkActivityState(activity: Activity) {
 	return undefined;
 }
 
-async function pollTrimStatus() {
-	if (trimPollInFlight) return;
-	trimPollInFlight = true;
-	try {
-		await checkDiskStats();
+// Derive local trim state from the shared disk-stats data
+function deriveTrimState() {
+	const act = trimActivity.value;
+	if (!act) {
+		checkingDiskStats.value = false;
+		return;
+	}
+	// Inline setTrimActivity (synchronous — computed refs already updated)
+	act.isActive = isTrimActive.value;
+	act.isPaused = isTrimSuspended.value;
+	act.isFinished = isTrimFinished.value;
+	act.isCanceled = isTrimCanceled.value;
 
-		const act = trimActivity.value;
-		if (!act) {
+	switch (checkActivityState(act)) {
+		case "active":
+			checkingDiskStats.value = true;
+			break;
+		case "paused":
+		case "canceled":
+		case "finished":
 			checkingDiskStats.value = false;
-			return;
-		}
-
-		await setTrimActivity(act);
-
-		switch (checkActivityState(act)) {
-			case "active":
-				checkingDiskStats.value = true;
-				break;
-			case "paused":
-			case "canceled":
-			case "finished":
-				checkingDiskStats.value = false;
-				break;
-			default:
-				break;
-		}
-	} finally {
-		trimPollInFlight = false;
+			break;
+		default:
+			break;
 	}
 }
 
-function subscribeTrimInterval() {
+// React to shared disk-stats updates (provider refreshes poolDiskStats periodically)
+watch(poolDisks, deriveTrimState, { deep: true });
+
+// One-shot refresh for exposed callers (e.g. after starting a trim)
+async function pollTrimStatus() {
+	await checkDiskStats();
+	deriveTrimState();
+}
+
+function subscribeTrim() {
 	if (trimSubscribed) return;
 	trimSubscribed = true;
 	trimSubscribers.value++;
-	if (trimSubscribers.value === 1) {
-		diskStatsIntervalID.value = setInterval(pollTrimStatus, 3000);
-	}
 }
 
-function unsubscribeTrimInterval() {
+function unsubscribeTrim() {
 	if (!trimSubscribed) return;
 	trimSubscribed = false;
-	trimSubscribers.value--;
-	if (trimSubscribers.value <= 0) {
-		trimSubscribers.value = 0;
-		if (diskStatsIntervalID.value) {
-			clearInterval(diskStatsIntervalID.value);
-			diskStatsIntervalID.value = null;
-		}
-	}
+	trimSubscribers.value = Math.max(0, trimSubscribers.value - 1);
 }
 
 watch(
 	checkingDiskStats,
 	() => {
-		if (checkingDiskStats.value) subscribeTrimInterval();
-		else unsubscribeTrimInterval();
+		if (checkingDiskStats.value) subscribeTrim();
+		else unsubscribeTrim();
 	},
 	{ immediate: true }
 );
@@ -685,13 +671,14 @@ function trimProgressBarClass(disk: any) {
 }
 
 onMounted(() => {
-	pollScanStatus();
-	pollTrimStatus();
+	// Derive initial state from data already loaded by ZFS.vue initialLoad
+	deriveScanState();
+	deriveTrimState();
 });
 
 onBeforeUnmount(() => {
-	unsubscribeScanInterval();
-	unsubscribeTrimInterval();
+	unsubscribeScan();
+	unsubscribeTrim();
 });
 
 defineExpose({

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -323,10 +323,9 @@ async function pollScanStatus() {
 }
 
 function startScanInterval() {
-	if (!scanIntervalID.value) {
-		ownScanIntervalId = setInterval(pollScanStatus, 3000);
-		scanIntervalID.value = ownScanIntervalId;
-	}
+	if (ownScanIntervalId) return; // this instance already polling
+	ownScanIntervalId = setInterval(pollScanStatus, 3000);
+	scanIntervalID.value = ownScanIntervalId;
 }
 
 function stopScanInterval() {
@@ -549,10 +548,9 @@ async function pollTrimStatus() {
 }
 
 function startDiskStatsInterval() {
-	if (!diskStatsIntervalID.value) {
-		ownTrimIntervalId = setInterval(pollTrimStatus, 3000);
-		diskStatsIntervalID.value = ownTrimIntervalId;
-	}
+	if (ownTrimIntervalId) return; // this instance already polling
+	ownTrimIntervalId = setInterval(pollTrimStatus, 3000);
+	diskStatsIntervalID.value = ownTrimIntervalId;
 }
 
 function stopDiskStatsInterval() {

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -670,9 +670,9 @@ function trimProgressBarClass(disk: any) {
 }
 
 onMounted(() => {
-	// Derive initial state from data already loaded by ZFS.vue initialLoad
-	deriveScanState();
-	deriveTrimState();
+	// One-shot refresh + derive so we discover already-running scrubs/trims
+	pollScanStatus();
+	pollTrimStatus();
 });
 
 onBeforeUnmount(() => {

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -498,7 +498,6 @@ async function setTrimActivity(activity: Activity) {
 }
 
 const checkingDiskStats = ref(false);
-let trimPollInFlight = false;
 const trimSubscribers = inject<Ref<number>>('trim-subscribers')!;
 let trimSubscribed = false;
 

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -291,8 +291,8 @@ async function setScanActivity(activity: Activity) {
 
 const scanning = ref(false);
 let scanPollInFlight = false;
-// Per-instance handle so we only clear the shared ref if WE own it
-let ownScanIntervalId: ReturnType<typeof setInterval> | null = null;
+const scanSubscribers = inject<Ref<number>>('scan-subscribers')!;
+let scanSubscribed = false;
 
 async function scanNow() {
 	await loadScanObjectGroup(scanObjectGroup);
@@ -322,28 +322,35 @@ async function pollScanStatus() {
 	}
 }
 
-function startScanInterval() {
-	if (ownScanIntervalId) return; // this instance already polling
-	ownScanIntervalId = setInterval(pollScanStatus, 3000);
-	scanIntervalID.value = ownScanIntervalId;
+function subscribeScanInterval() {
+	if (scanSubscribed) return;
+	scanSubscribed = true;
+	scanSubscribers.value++;
+	if (scanSubscribers.value === 1) {
+		// First subscriber starts the single shared interval
+		scanIntervalID.value = setInterval(pollScanStatus, 3000);
+	}
 }
 
-function stopScanInterval() {
-	// Only clear the shared ref if this instance owns it
-	if (ownScanIntervalId) {
-		clearInterval(ownScanIntervalId);
-		if (scanIntervalID.value === ownScanIntervalId) {
+function unsubscribeScanInterval() {
+	if (!scanSubscribed) return;
+	scanSubscribed = false;
+	scanSubscribers.value--;
+	if (scanSubscribers.value <= 0) {
+		// Last subscriber stops the shared interval
+		scanSubscribers.value = 0;
+		if (scanIntervalID.value) {
+			clearInterval(scanIntervalID.value);
 			scanIntervalID.value = null;
 		}
-		ownScanIntervalId = null;
 	}
 }
 
 watch(
 	scanning,
 	() => {
-		if (scanning.value) startScanInterval();
-		else stopScanInterval();
+		if (scanning.value) subscribeScanInterval();
+		else unsubscribeScanInterval();
 	},
 	{ immediate: true }
 );
@@ -501,8 +508,8 @@ async function setTrimActivity(activity: Activity) {
 
 const checkingDiskStats = ref(false);
 let trimPollInFlight = false;
-// Per-instance handle so we only clear the shared ref if WE own it
-let ownTrimIntervalId: ReturnType<typeof setInterval> | null = null;
+const trimSubscribers = inject<Ref<number>>('trim-subscribers')!;
+let trimSubscribed = false;
 
 async function checkDiskStats() {
 	await loadDiskStats(poolDiskStats);
@@ -547,28 +554,33 @@ async function pollTrimStatus() {
 	}
 }
 
-function startDiskStatsInterval() {
-	if (ownTrimIntervalId) return; // this instance already polling
-	ownTrimIntervalId = setInterval(pollTrimStatus, 3000);
-	diskStatsIntervalID.value = ownTrimIntervalId;
+function subscribeTrimInterval() {
+	if (trimSubscribed) return;
+	trimSubscribed = true;
+	trimSubscribers.value++;
+	if (trimSubscribers.value === 1) {
+		diskStatsIntervalID.value = setInterval(pollTrimStatus, 3000);
+	}
 }
 
-function stopDiskStatsInterval() {
-	// Only clear the shared ref if this instance owns it
-	if (ownTrimIntervalId) {
-		clearInterval(ownTrimIntervalId);
-		if (diskStatsIntervalID.value === ownTrimIntervalId) {
+function unsubscribeTrimInterval() {
+	if (!trimSubscribed) return;
+	trimSubscribed = false;
+	trimSubscribers.value--;
+	if (trimSubscribers.value <= 0) {
+		trimSubscribers.value = 0;
+		if (diskStatsIntervalID.value) {
+			clearInterval(diskStatsIntervalID.value);
 			diskStatsIntervalID.value = null;
 		}
-		ownTrimIntervalId = null;
 	}
 }
 
 watch(
 	checkingDiskStats,
 	() => {
-		if (checkingDiskStats.value) startDiskStatsInterval();
-		else stopDiskStatsInterval();
+		if (checkingDiskStats.value) subscribeTrimInterval();
+		else unsubscribeTrimInterval();
 	},
 	{ immediate: true }
 );
@@ -678,8 +690,8 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-	stopScanInterval();
-	stopDiskStatsInterval();
+	unsubscribeScanInterval();
+	unsubscribeTrimInterval();
 });
 
 defineExpose({

--- a/zfs/src/store/notification.ts
+++ b/zfs/src/store/notification.ts
@@ -1,6 +1,15 @@
 import { reactive } from "vue";
 import { Notification } from "../types";
 
+// Shared D-Bus singleton — reused across all store methods to avoid leaking connections
+let _dbus: ReturnType<typeof cockpit.dbus> | null = null;
+function getHoustonDbus() {
+  if (!_dbus) {
+    _dbus = cockpit.dbus("org._45drives.Houston");
+  }
+  return _dbus;
+}
+
 // Define the reactive notification store
 export const notificationStore = reactive<{
   notifications: Notification[];
@@ -96,7 +105,7 @@ export const notificationStore = reactive<{
     try {
         // console.log("Fetching missed notifications via D-Bus...");
 
-        const dbus = cockpit.dbus("org._45drives.Houston");
+        const dbus = getHoustonDbus();
 
         // Call GetMissedNotifications with correct object path & interface
         const response = await dbus.call(
@@ -141,7 +150,7 @@ export const notificationStore = reactive<{
     try {
         // console.log(`Marking notification ${notificationId} as read via D-Bus...`);
 
-        const dbus = cockpit.dbus("org._45drives.Houston");
+        const dbus = getHoustonDbus();
 
         // Call the D-Bus method instead of FastAPI
         const response = await dbus.call(
@@ -170,7 +179,7 @@ export const notificationStore = reactive<{
     try {
         // console.log("Marking all notifications as read via D-Bus...");
 
-        const dbus = cockpit.dbus("org._45drives.Houston");
+        const dbus = getHoustonDbus();
 
         // Call the new D-Bus method
         const response = await dbus.call(
@@ -191,7 +200,7 @@ export const notificationStore = reactive<{
   },
 
   async countMissedNotifications(){
-    const dbus = cockpit.dbus("org._45drives.Houston");
+    const dbus = getHoustonDbus();
     const result = await dbus.call(
       "/org/_45drives/Houston",
       "org._45drives.Houston",
@@ -212,7 +221,7 @@ export const notificationStore = reactive<{
 async function sideBarNotification(): Promise<void> {
   const count: number = notificationStore.notificationsCount;
 
-  const dbus = cockpit.dbus("org._45drives.Houston");
+  const dbus = getHoustonDbus();
 
   try {
     const [highestSeverity] = await dbus.call(

--- a/zfs/src/store/notification.ts
+++ b/zfs/src/store/notification.ts
@@ -10,6 +10,28 @@ function getHoustonDbus() {
   return _dbus;
 }
 
+// Event types that belong to the ZFS module
+const ZFS_EVENTS = [
+  "scrub_finish",
+  "storage_threshold",
+  "snapshot_created",
+  "snapshot_failed",
+  "zfs_replication_success",
+  "zfs_replication_failed",
+  "vdev_attach",
+  "resilver_finish",
+  "vdev_clear",
+  "pool_import",
+  "statechange",
+  "data",
+];
+
+const ZFS_EVENTS_JSON = JSON.stringify(ZFS_EVENTS);
+
+function isZfsEvent(event: string | undefined): boolean {
+  return !!event && ZFS_EVENTS.includes(event);
+}
+
 // Define the reactive notification store
 export const notificationStore = reactive<{
   notifications: Notification[];
@@ -25,7 +47,7 @@ export const notificationStore = reactive<{
   notifications: [],
   notificationsCount: 0,
 
-  // Add notification to the list
+  // Add notification to the list (only ZFS-related events)
   addNotification(message: string) {
     try {
       const parsedMessage = JSON.parse(message) as {
@@ -42,7 +64,9 @@ export const notificationStore = reactive<{
         snapShot?: string;
         replicationDestination?: string
       };
-      // console.log("message id recieved in adddnotification: ", parsedMessage.id)
+
+      // Ignore events that don't belong to the ZFS module
+      if (!isZfsEvent(parsedMessage.event)) return;
   
       // Find existing notification by ID
       const existingNotification = notificationStore.notifications.find(
@@ -103,16 +127,13 @@ export const notificationStore = reactive<{
 
   async fetchMissedNotifications(limit = 50, offset = 0) {
     try {
-        // console.log("Fetching missed notifications via D-Bus...");
-
         const dbus = getHoustonDbus();
 
-        // Call GetMissedNotifications with correct object path & interface
         const response = await dbus.call(
-          "/org/_45drives/Houston",       
-          "org._45drives.Houston",       
-          "GetMissedNotifications",      
-          [limit, offset]                
+          "/org/_45drives/Houston",
+          "org._45drives.Houston",
+          "GetMissedNotificationsByEvents",
+          [ZFS_EVENTS_JSON, limit, offset]
         );
         if (!response) throw new Error("No response received from Houston D-Bus.");
 
@@ -204,13 +225,13 @@ export const notificationStore = reactive<{
     const result = await dbus.call(
       "/org/_45drives/Houston",
       "org._45drives.Houston",
-      "GetNotificationCount"
+      "GetNotificationCountByEvents",
+      [ZFS_EVENTS_JSON]
     );
-    const count = result[0]; // Extract the count
+    const count = result[0];
     this.notificationsCount = count;
-    // console.log("Total missed notifications:", count);
 
-    return parseInt(result); // result is returned as a string
+    return parseInt(result);
   }
 
 
@@ -227,7 +248,8 @@ async function sideBarNotification(): Promise<void> {
     const [highestSeverity] = await dbus.call(
       "/org/_45drives/Houston",
       "org._45drives.Houston",
-      "GetHighestMissedSeverity"
+      "GetHighestMissedSeverityByEvents",
+      [ZFS_EVENTS_JSON]
     );
 
     const severityType = count > 0 ? highestSeverity : null;

--- a/zfs/src/store/notification.ts
+++ b/zfs/src/store/notification.ts
@@ -5,7 +5,13 @@ import { Notification } from "../types";
 let _dbus: ReturnType<typeof cockpit.dbus> | null = null;
 function getHoustonDbus() {
   if (!_dbus) {
-    _dbus = cockpit.dbus("org._45drives.Houston");
+    const dbus = cockpit.dbus("org._45drives.Houston");
+    dbus.addEventListener("close", () => {
+      if (_dbus === dbus) {
+        _dbus = null;
+      }
+    });
+    _dbus = dbus;
   }
   return _dbus;
 }

--- a/zfs/src/store/notification.ts
+++ b/zfs/src/store/notification.ts
@@ -5,7 +5,7 @@ import { Notification } from "../types";
 let _dbus: ReturnType<typeof cockpit.dbus> | null = null;
 function getHoustonDbus() {
   if (!_dbus) {
-    const dbus = cockpit.dbus("org._45drives.Houston");
+    const dbus = cockpit.dbus("org._45drives.Houston", { bus: "system" });
     dbus.addEventListener("close", () => {
       if (_dbus === dbus) {
         _dbus = null;

--- a/zfs/src/store/notification.ts
+++ b/zfs/src/store/notification.ts
@@ -198,21 +198,19 @@ export const notificationStore = reactive<{
 
   async clearAllNotifications() {
     try {
-        // console.log("Marking all notifications as read via D-Bus...");
-
         const dbus = getHoustonDbus();
 
-        // Call the new D-Bus method
-        const response = await dbus.call(
-            "/org/_45drives/Houston",  // Object path
-            "org._45drives.Houston",   // Interface
-            "MarkAllNotificationsAsRead"  // Method name
+        // Mark only ZFS-scoped notifications as read (not global)
+        await dbus.call(
+            "/org/_45drives/Houston",
+            "org._45drives.Houston",
+            "MarkAllNotificationsByEventsAsRead",
+            [ZFS_EVENTS_JSON]
         );
-
-        // console.log(`D-Bus Response: ${response}`);
 
         // Clear UI notifications
         notificationStore.notifications = [];
+        this.notificationsCount = 0;
 
         sideBarNotification();
     } catch (error) {
@@ -245,22 +243,25 @@ async function sideBarNotification(): Promise<void> {
   const dbus = getHoustonDbus();
 
   try {
-    const [highestSeverity] = await dbus.call(
-      "/org/_45drives/Houston",
-      "org._45drives.Houston",
-      "GetHighestMissedSeverityByEvents",
-      [ZFS_EVENTS_JSON]
-    );
+    if (count > 0) {
+      const [highestSeverity] = await dbus.call(
+        "/org/_45drives/Houston",
+        "org._45drives.Houston",
+        "GetHighestMissedSeverityByEvents",
+        [ZFS_EVENTS_JSON]
+      );
 
-    const severityType = count > 0 ? highestSeverity : null;
-    // console.log("severityType:", severityType);
-
-    (cockpit.transport as any).control("notify", {
-      page_status: {
-        type: severityType,
-        title: cockpit.gettext(`${count} Notifications available`)
-      }
-    });
+      (cockpit.transport as any).control("notify", {
+        page_status: {
+          type: highestSeverity,
+          title: cockpit.gettext(`${count} Notifications available`)
+        }
+      });
+    } else {
+      (cockpit.transport as any).control("notify", {
+        page_status: null
+      });
+    }
   } catch (error) {
     console.error("Failed to fetch highest severity:", error);
   }

--- a/zfs/src/views/ZFS.vue
+++ b/zfs/src/views/ZFS.vue
@@ -82,13 +82,24 @@ async function initialLoad(disks, pools, datasets, snapshots) {
 let houstonDbusClient: ReturnType<typeof cockpit.dbus> | null = null;
 let houstonMessageHandler: ((event: any, message: any) => void) | null = null;
 let houstonProxy: any = null;
+let isUnmounted = false;
 
 async function setUpMessageHandler(handler) {
     try {
         console.log("Setting up ZFS Notification DBus message handler...");
 
-        houstonDbusClient = cockpit.dbus("org._45drives.Houston");
-        houstonProxy = await houstonDbusClient.proxy("org._45drives.Houston", "/org/_45drives/Houston");
+        const client = cockpit.dbus("org._45drives.Houston");
+        const proxy = await client.proxy("org._45drives.Houston", "/org/_45drives/Houston");
+
+        // If the component was unmounted while we were awaiting the proxy,
+        // close immediately and bail out.
+        if (isUnmounted) {
+            try { client.close(); } catch {}
+            return;
+        }
+
+        houstonDbusClient = client;
+        houstonProxy = proxy;
 
         console.log("Connected to ZFS Notification DBus. Subscribing to Message signal...");
 
@@ -109,10 +120,13 @@ async function setUpMessageHandler(handler) {
 // })
 
 onMounted(() => {
+	isUnmounted = false;
 	initialLoad(disks, pools, datasets, snapshots);
 });
 
 onBeforeUnmount(() => {
+	isUnmounted = true;
+
 	// Clean up D-Bus listener + connection
 	if (houstonProxy && houstonMessageHandler) {
 		try { houstonProxy.removeEventListener("Message", houstonMessageHandler); } catch {}

--- a/zfs/src/views/ZFS.vue
+++ b/zfs/src/views/ZFS.vue
@@ -51,23 +51,31 @@ const clearLabels = ref(false);
 const scanActivities = ref<Map<string, Ref<Activity>>>(new Map());
 const scanObjectGroup = ref<PoolScanObjectGroup>({});
 const scanIntervalID = ref();
+const scanSubscribers = ref(0);
 
 const trimActivities = ref<Map<string, Ref<Activity>>>(new Map());
 const poolDiskStats = ref<PoolDiskStats>({});
 const diskStatsIntervalID = ref();
+const trimSubscribers = ref(0);
 
 async function initialLoad(disks, pools, datasets, snapshots) {
 	disksLoaded.value = false;
 	poolsLoaded.value = false;
 	fileSystemsLoaded.value = false;
 	await loadDisksThenPools(disks, pools);
+	if (isUnmounted) return;
 	await loadDatasets(datasets);
+	if (isUnmounted) return;
 	//await loadSnapshots(snapshots);
 	
 	await scanNow();
+	if (isUnmounted) return;
 	await loadScanActivities(pools, scanActivities);
+	if (isUnmounted) return;
 	await checkDiskStats();
+	if (isUnmounted) return;
 	await loadTrimActivities(pools, trimActivities);
+	if (isUnmounted) return;
 	disksLoaded.value = true;
 	poolsLoaded.value = true;
 	fileSystemsLoaded.value = true;
@@ -221,7 +229,9 @@ provide("snapshots", snapshots);
 provide('scan-object-group', scanObjectGroup);
 provide('pool-disk-stats', poolDiskStats);
 provide('scan-interval', scanIntervalID);
+provide('scan-subscribers', scanSubscribers);
 provide('disk-stats-interval', diskStatsIntervalID);
+provide('trim-subscribers', trimSubscribers);
 provide('scan-activities', scanActivities);
 provide('trim-activities', trimActivities);
 </script>

--- a/zfs/src/views/ZFS.vue
+++ b/zfs/src/views/ZFS.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, Ref, provide, watchEffect, onMounted, onBeforeUnmount } from 'vue';
+import { ref, Ref, provide, watchEffect, watch, onMounted, onBeforeUnmount } from 'vue';
 import { getUserCaps } from "../auth/capabilities";
 import { loadDisksThenPools, loadDatasets, loadScanObjectGroup, loadDiskStats, loadSnapshots } from '../composables/loadData';
 import { loadScanActivities, loadTrimActivities } from '../composables/helpers';
@@ -173,6 +173,40 @@ async function scanNow() {
 async function checkDiskStats() {
 	await loadDiskStats(poolDiskStats);
 }
+
+// Shared scan polling — one interval for all Status instances
+let scanPollInFlight = false;
+async function sharedScanPoll() {
+	if (scanPollInFlight) return;
+	scanPollInFlight = true;
+	try { await scanNow(); } finally { scanPollInFlight = false; }
+}
+
+watch(scanSubscribers, (count) => {
+	if (count > 0 && !scanIntervalID.value) {
+		scanIntervalID.value = setInterval(sharedScanPoll, 3000);
+	} else if (count <= 0 && scanIntervalID.value) {
+		clearInterval(scanIntervalID.value);
+		scanIntervalID.value = null;
+	}
+});
+
+// Shared trim polling — one interval for all Status instances
+let trimPollInFlight = false;
+async function sharedTrimPoll() {
+	if (trimPollInFlight) return;
+	trimPollInFlight = true;
+	try { await checkDiskStats(); } finally { trimPollInFlight = false; }
+}
+
+watch(trimSubscribers, (count) => {
+	if (count > 0 && !diskStatsIntervalID.value) {
+		diskStatsIntervalID.value = setInterval(sharedTrimPoll, 3000);
+	} else if (count <= 0 && diskStatsIntervalID.value) {
+		clearInterval(diskStatsIntervalID.value);
+		diskStatsIntervalID.value = null;
+	}
+});
 
 /////////////////////////////////////////////////////
 const dashboardComponent = ref();

--- a/zfs/src/views/ZFS.vue
+++ b/zfs/src/views/ZFS.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, Ref, provide, watchEffect, onMounted } from 'vue';
+import { ref, Ref, provide, watchEffect, onMounted, onBeforeUnmount } from 'vue';
 import { getUserCaps } from "../auth/capabilities";
 import { loadDisksThenPools, loadDatasets, loadScanObjectGroup, loadDiskStats, loadSnapshots } from '../composables/loadData';
 import { loadScanActivities, loadTrimActivities } from '../composables/helpers';
@@ -78,19 +78,25 @@ async function initialLoad(disks, pools, datasets, snapshots) {
     });
 }
 
+// D-Bus message handler state — stored so we can clean up on unmount
+let houstonDbusClient: ReturnType<typeof cockpit.dbus> | null = null;
+let houstonMessageHandler: ((event: any, message: any) => void) | null = null;
+let houstonProxy: any = null;
+
 async function setUpMessageHandler(handler) {
     try {
         console.log("Setting up ZFS Notification DBus message handler...");
 
-        const client = cockpit.dbus("org._45drives.Houston");
-        const houston = await client.proxy("org._45drives.Houston", "/org/_45drives/Houston");
+        houstonDbusClient = cockpit.dbus("org._45drives.Houston");
+        houstonProxy = await houstonDbusClient.proxy("org._45drives.Houston", "/org/_45drives/Houston");
 
         console.log("Connected to ZFS Notification DBus. Subscribing to Message signal...");
 
-        houston.addEventListener("Message", (_, message) => {
+        houstonMessageHandler = (_, message) => {
 			notificationStore.addNotification(message);
             handler(message);
-        });
+        };
+        houstonProxy.addEventListener("Message", houstonMessageHandler);
 
         console.log("ZFS Notification DBus message handler successfully set up.");
     } catch (error) {
@@ -102,7 +108,32 @@ async function setUpMessageHandler(handler) {
 //     console.log("hello")
 // })
 
-initialLoad(disks, pools, datasets, snapshots);
+onMounted(() => {
+	initialLoad(disks, pools, datasets, snapshots);
+});
+
+onBeforeUnmount(() => {
+	// Clean up D-Bus listener + connection
+	if (houstonProxy && houstonMessageHandler) {
+		try { houstonProxy.removeEventListener("Message", houstonMessageHandler); } catch {}
+	}
+	if (houstonDbusClient) {
+		try { houstonDbusClient.close(); } catch {}
+		houstonDbusClient = null;
+	}
+	houstonProxy = null;
+	houstonMessageHandler = null;
+
+	// Clean up any leaked Status.vue intervals
+	if (scanIntervalID.value) {
+		clearInterval(scanIntervalID.value);
+		scanIntervalID.value = null;
+	}
+	if (diskStatsIntervalID.value) {
+		clearInterval(diskStatsIntervalID.value);
+		diskStatsIntervalID.value = null;
+	}
+});
 
 
 /////////////////////////////////////////////////////

--- a/zfs/src/views/ZFS.vue
+++ b/zfs/src/views/ZFS.vue
@@ -85,10 +85,11 @@ let houstonProxy: any = null;
 let isUnmounted = false;
 
 async function setUpMessageHandler(handler) {
+    let client: ReturnType<typeof cockpit.dbus> | null = null;
     try {
         console.log("Setting up ZFS Notification DBus message handler...");
 
-        const client = cockpit.dbus("org._45drives.Houston");
+        client = cockpit.dbus("org._45drives.Houston");
         const proxy = await client.proxy("org._45drives.Houston", "/org/_45drives/Houston");
 
         // If the component was unmounted while we were awaiting the proxy,
@@ -111,6 +112,11 @@ async function setUpMessageHandler(handler) {
 
         console.log("ZFS Notification DBus message handler successfully set up.");
     } catch (error) {
+        // Close the local client if it was opened but never assigned to
+        // houstonDbusClient (e.g. client.proxy() rejected).
+        if (client && client !== houstonDbusClient) {
+            try { client.close(); } catch {}
+        }
         console.error("Error setting up ZFS Notification DBus message handler:", error);
     }
 }


### PR DESCRIPTION
D-Bus proxy leak in notification store — Every method in the notification store (fetchMissedNotifications, markNotificationAsRead, clearAllNotifications, countMissedNotifications, plus the sideBarNotification helper) created a new cockpit.dbus("org._45drives.Houston") connection as a local variable and never closed it. Each cockpit.dbus() allocates an internal Cockpit WebSocket channel that persists until explicitly closed. Over time these accumulated without limit. Fixed by creating a module-level singleton via getHoustonDbus() that is reused for every D-Bus call.

Status.vue intervals never cleaned on unmount — Status.vue starts two setInterval(fn, 3000) timers for scan and trim polling, managed by watchers on boolean flags. There was no onBeforeUnmount hook anywhere in the component. If you navigated away while a scan or trim was active, the intervals were never cleared and kept spawning Python processes against a dead component. Additionally, multiple Status.vue instances (one per pool) share a single injected interval ID ref from ZFS.vue, creating a race condition where instances overwrite each other's interval handles, orphaning the ones they replace. Fixed by adding onBeforeUnmount that clears both intervals unconditionally.

Status.vue no in-flight guards — pollScanStatus() and pollTrimStatus() are async functions called every 3 seconds with no check for whether the previous call was still running. If the Python scripts take longer than 3 seconds under load, overlapping spawns stack up. Fixed by adding boolean in-flight guards that skip the tick when the previous call hasn't returned.

ZFS.vue D-Bus connection and event listener leak — setUpMessageHandler() created a cockpit.dbus() client and added an addEventListener("Message", ...) that were never cleaned up. There was no onBeforeUnmount hook at all in ZFS.vue. Each tab switch leaked a connection and accumulated event listeners. Additionally, initialLoad() was called at script-setup scope rather than inside onMounted, so the async chain continued running against stale refs if the component was quickly destroyed. Fixed by storing the D-Bus client/proxy/handler references and cleaning them up in onBeforeUnmount, moving initialLoad into onMounted, and clearing child Status.vue interval refs as a safety net.