### PR TITLE
Fix ZFS disk identity and completed scan display

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,6 +2909,7 @@ __metadata:
     typescript: "npm:^5.0.4"
     vite: "npm:^3.2.6"
     vite-plugin-vue-type-imports: "npm:^0.2.0"
+    vitest: "npm:^1.6.0"
     vue: "npm:^3.2.37"
   languageName: unknown
   linkType: soft

--- a/zfs/package.json
+++ b/zfs/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@45drives/houston-common-css": "workspace:^",
@@ -33,6 +34,7 @@
     "tailwindcss": "^3.1.8",
     "typescript": "^5.0.4",
     "vite": "^3.2.6",
-    "vite-plugin-vue-type-imports": "^0.2.0"
+    "vite-plugin-vue-type-imports": "^0.2.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/zfs/src/components/common/Status.vue
+++ b/zfs/src/components/common/Status.vue
@@ -194,7 +194,7 @@
 
 <script setup lang="ts">
 import { ref, inject, Ref, computed, ComputedRef, onMounted, onBeforeUnmount, watch } from "vue";
-import { convertBytesToSize, convertSecondsToString, convertRawTimestampToString, upperCaseWord, convertTimestampToLocal, findMatchingPoolDisk } from "../../composables/helpers";
+import { convertBytesToSize, convertSecondsToString, convertRawTimestampToString, upperCaseWord, convertTimestampToLocal, findMatchingPoolDisk, normalizeScanProgress } from "../../composables/helpers";
 import { loadScanObjectGroup, loadDiskStats } from "../../composables/loadData";
 import { ZPool, VDevDisk } from "@45drives/houston-common-lib";
 import { PoolScanObjectGroup, Activity, PoolDiskStats } from "../../types";
@@ -412,16 +412,15 @@ const displayMiniStateMsg = computed(() => {
 	return miniStateMsg.value;
 });
 
-const scanPercentage = computed(() => (poolScan.value as any)?.percentage ?? 0);
-
-const adjustedScanPercentage = computed(() => {
-	const pct = parseFloat(scanPercentage.value.toFixed(2));
-	if (isFinished.value && pct > 90) return 100;
-	return pct;
-});
-
-const amountProcessed = computed(() => convertBytesToSize((poolScan.value as any)?.bytes_issued ?? 0));
-const amountTotal = computed(() => convertBytesToSize((poolScan.value as any)?.bytes_processed ?? 0));
+const normalizedScanProgress = computed(() => normalizeScanProgress(poolScan.value));
+const scanPercentage = computed(() => normalizedScanProgress.value.percentage);
+const adjustedScanPercentage = computed(() => normalizedScanProgress.value.percentage);
+const amountProcessed = computed(() =>
+	convertBytesToSize(normalizedScanProgress.value.processedBytes),
+);
+const amountTotal = computed(() =>
+	convertBytesToSize(normalizedScanProgress.value.totalBytes),
+);
 const timeRemaining = computed(() => convertSecondsToString((poolScan.value as any)?.total_secs_left ?? 0));
 
 function stateMessageClass() {

--- a/zfs/src/composables/helpers.ts
+++ b/zfs/src/composables/helpers.ts
@@ -630,6 +630,26 @@ export function getDiskIDName(disks: VDevDisk[], diskIdentifier: string, selecte
 
 
 // One canonical matcher. Works with reactive arrays (pass disks.value) or plain arrays.
+export function normalizeDiskPath(path?: string): string {
+	if (!path) return "";
+	return path
+		.replace(/(\/nvme\d+n\d+)p\d+$/, "$1")
+		.replace(/(\/mmcblk\d+)p\d+$/, "$1")
+		.replace(/(\/sd[a-z]+)\d+$/, "$1")
+		.replace(/-part\d+$/, "")
+		.replace(/(-ata-\d+)\.0(?=$|-)/, "$1");
+}
+
+export function getDiskPathCandidates(disk: any): string[] {
+	const scalarKeys = [
+		"sd_path", "phy_path", "vdev_path", "id_path", "label_path",
+		"part_label_path", "part_uuid", "uuid",
+	];
+	const scalarPaths = scalarKeys.map((key) => disk?.[key]);
+	const aliasPaths = Array.isArray(disk?.id_paths) ? disk.id_paths : [];
+	return [...new Set([...scalarPaths, ...aliasPaths].filter(Boolean))] as string[];
+}
+
 export function matchDiskByVdevOrPath(
 	disksLike: MaybeRef<VDevDisk[]>,
 	vdevPathOrAnyPath: string
@@ -649,17 +669,6 @@ export function matchDiskByVdevOrPath(
 		if (hit) return hit;
 	}
 
-	const clean = (p?: string) => {
-		if (!p) return "";
-		p = p.replace(/(\/nvme\d+n\d+)p\d+$/, "$1");
-		p = p.replace(/(\/mmcblk\d+)p\d+$/, "$1");
-		p = p.replace(/(\/sd[a-z]+)\d+$/, "$1");
-		p = p.replace(/-part\d+$/, "");
-		// Normalize ATA SCSI target suffixes: ata-3.0 ↔ ata-3
-		p = p.replace(/(-ata-\d+)\.0(?=$|-)/, "$1");
-		return p;
-	};
-
 	const sameOrStartsWith = (a: string, b: string) => {
 		if (!a || !b) return false;
 		if (a === b) return true;
@@ -672,21 +681,23 @@ export function matchDiskByVdevOrPath(
 	};
 
 	const want = vdevPathOrAnyPath;
-	const wantBase = clean(want);
+	const wantBase = normalizeDiskPath(want);
 
-	const candidates = ["sd_path", "phy_path", "vdev_path", "id_path", "label_path", "part_label_path", "part_uuid", "uuid"];
+	let disk = disks.find((candidate) =>
+		getDiskPathCandidates(candidate).some(
+			(path) => path === want || normalizeDiskPath(path) === wantBase,
+		),
+	);
+	if (disk) return disk;
 
-	let d = disks.find(dd => candidates.some(k => {
-		const v = (dd as any)?.[k] as string | undefined;
-		return v === want || clean(v) === wantBase;
-	}));
-	if (d) return d;
-
-	d = disks.find(dd => candidates.some(k => {
-		const v = ((dd as any)?.[k] as string | undefined) ?? "";
-		return sameOrStartsWith(v, want) || sameOrStartsWith(clean(v), wantBase);
-	}));
-	return d;
+	disk = disks.find((candidate) =>
+		getDiskPathCandidates(candidate).some(
+			(path) =>
+				sameOrStartsWith(path, want)
+				|| sameOrStartsWith(normalizeDiskPath(path), wantBase),
+		),
+	);
+	return disk;
 }
 
 

--- a/zfs/src/composables/helpers.ts
+++ b/zfs/src/composables/helpers.ts
@@ -172,28 +172,42 @@ export function convertRawTimestampToString(rawTimestamp) {
     return timestamp.substring(0, 19);
 }
 
-export function convertTimestampToLocal(timestamp) {
-    // Check if the timestamp already has a space between date and time
-    const hasSpace = timestamp.includes(' ');
+export function convertTimestampToLocal(
+    timestamp: string | number | null | undefined,
+): string {
+    if (timestamp === null || timestamp === undefined) return "N/A";
 
-    // If it has a space, use it directly; otherwise, convert to the desired format
-    const utcTimestamp = hasSpace ? timestamp.replace(' ', 'T') + 'Z' : timestamp;
+    let date: Date;
+    if (typeof timestamp === "number") {
+        const milliseconds = Math.abs(timestamp) < 1e12 ? timestamp * 1000 : timestamp;
+        date = new Date(milliseconds);
+    } else {
+        const raw = timestamp.trim();
+        if (!raw) return "N/A";
+        const separated = raw.includes(" ") ? raw.replace(" ", "T") : raw;
+        const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(separated);
+        const normalized = hasZone ? separated : `${separated}Z`;
+        date = new Date(normalized);
+    }
 
-    const localTimestamp = new Date(utcTimestamp).toLocaleString('en-US', {
-        year: 'numeric', month: '2-digit', day: '2-digit',
-        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
-    });
+    if (Number.isNaN(date.getTime())) return "N/A";
 
-    const rearrangedTimestamp = localTimestamp.replace(/\//g, '-').replace(',', '');
+    const parts = Object.fromEntries(
+        new Intl.DateTimeFormat("en-CA", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hourCycle: "h23",
+        })
+            .formatToParts(date)
+            .filter(({ type }) => type !== "literal")
+            .map(({ type, value }) => [type, value]),
+    );
 
-    const [date, time] = rearrangedTimestamp.split(' ');
-
-    const [month, day, year] = date.split('-');
-    const rearrangedDate = `${year}-${month}-${day}`;
-
-    const finalTimestamp = `${rearrangedDate} ${time}`;
-
-    return finalTimestamp;
+    return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second}`;
 }
 
 export function convertTimestampFormat(timestamp) {

--- a/zfs/src/composables/helpers.ts
+++ b/zfs/src/composables/helpers.ts
@@ -53,6 +53,39 @@ export const convertBytesToSize = (bytes: number, precision: number = 2): string
 	return `${convertedSize} ${binarySizes[i]}`;
 };
 
+export function normalizeScanProgress(scan: any): {
+	percentage: number;
+	processedBytes: number;
+	totalBytes: number;
+} {
+	const safeNumber = (value: unknown): number | undefined => {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+	};
+
+	const processed = safeNumber(scan?.bytes_processed)
+		?? safeNumber(scan?.bytes_issued)
+		?? 0;
+	const total = safeNumber(scan?.bytes_to_process)
+		?? safeNumber(scan?.bytes_processed)
+		?? processed;
+
+	if (scan?.state === "FINISHED") {
+		const finishedTotal = Math.max(total, processed);
+		return {
+			percentage: 100,
+			processedBytes: finishedTotal,
+			totalBytes: finishedTotal,
+		};
+	}
+
+	return {
+		percentage: Math.min(100, Math.max(0, safeNumber(scan?.percentage) ?? 0)),
+		processedBytes: Math.min(processed, total),
+		totalBytes: total,
+	};
+}
+
 
 // Convert readable binary data size to raw bytes
 export const convertSizeToBytes = (size: string): number => {

--- a/zfs/src/composables/loadData.ts
+++ b/zfs/src/composables/loadData.ts
@@ -2,7 +2,7 @@ import { ref, Ref } from 'vue';
 import { getPools } from "./pools";
 import { getDisks } from "./disks";
 import { getDatasets } from "./datasets";
-import { matchDiskByVdevOrPath, convertBytesToSize, onOffToBool, getQuotaRefreservUnit, getSizeUnitFromString, getParentPath, convertTimestampToLocal, formatCapacityString, isCapacityPatternInvalid, changeUnitToBinary } from "./helpers";
+import { matchDiskByVdevOrPath, getDiskPathCandidates, normalizeDiskPath, convertBytesToSize, onOffToBool, getQuotaRefreservUnit, getSizeUnitFromString, getParentPath, convertTimestampToLocal, formatCapacityString, isCapacityPatternInvalid, changeUnitToBinary } from "./helpers";
 import { getSnapshots, getSnapshotsOfDataset, getSnapshotsOfPool } from './snapshots';
 import { getDiskStats, getScanGroup } from './scan';
 import { VDevDisk, ZFSFileSystemInfo, VDev } from "@45drives/houston-common-lib"
@@ -117,6 +117,7 @@ export async function loadDisksThenPools(disks, pools) {
 				errors: parsedJSON[i].health === 'POOR' ? ['SMART health: POOR'] : [],
 				hasPartitions: parsedJSON[i].has_partitions || false,
 				id_path: parsedJSON[i].id_path || '',
+				id_paths: parsedJSON[i].id_paths || [],
 				label_path: parsedJSON[i].label_path || '',
 				part_label_path: parsedJSON[i].part_label_path || '',
 				part_uuid: parsedJSON[i].part_uuid || '',
@@ -445,6 +446,7 @@ export async function loadDisks(disks) {
 				errors: parsedJSON[i].health === 'POOR' ? ['SMART health: POOR'] : [],
 				hasPartitions: parsedJSON[i].has_partitions || false,
 				id_path: parsedJSON[i].id_path || '',
+				id_paths: parsedJSON[i].id_paths || [],
 				label_path: parsedJSON[i].label_path || '',
 				part_label_path: parsedJSON[i].part_label_path || '',
 				part_uuid: parsedJSON[i].part_uuid || '',
@@ -462,44 +464,13 @@ export async function loadDisks(disks) {
 	}
 }
 
-// Helper function to clean disk paths by removing partition numbers but leaving the rest intact
-function cleanDiskPath(path) {
-	if (!path) return '';
-
-	let result = path;
-
-	// Remove partition numbers from standard disks (e.g., /dev/sda1 → /dev/sda, /dev/sdab1 → /dev/sdab)
-	if (/\/dev\/sd[a-z]+\d+$/.test(result)) {
-		result = result.replace(/\d+$/, '');
-	}
-	// Remove 'pN' from NVMe paths (e.g., /dev/nvme0n1p2 → /dev/nvme0n1)
-	else if (/\/dev\/nvme\d+n\d+p\d+$/.test(result)) {
-		result = result.replace(/p\d+$/, '');
-	}
-	// Remove 'pN' from mmcblk paths (e.g., /dev/mmcblk0p1 → /dev/mmcblk0)
-	else if (/\/dev\/mmcblk\d+p\d+$/.test(result)) {
-		result = result.replace(/p\d+$/, '');
-	}
-	// Remove '-partN' suffix (e.g., /dev/disk/by-vdev/1-1-part1, /dev/disk/by-id/...-part2, /dev/disk/by-path/...-part1)
-	else if (/-part\d+$/.test(result)) {
-		result = result.replace(/-part\d+$/, '');
-	}
-
-	// Normalize ATA SCSI target suffixes: ata-3.0 ↔ ata-3
-	// TrueNAS uses ata-X, Rocky/RHEL uses ata-X.0 — strip trailing .0 for consistent matching
-	// Applied AFTER partition stripping so both ata-3.0-part2 and ata-3.0 normalize to ata-3
-	result = result.replace(/(-ata-\d+)\.0(?=$|-)/, '$1');
-
-	return result;
-}
-
 export async function loadDisksExtraData(disks, pools) {
 	try {
 		pools.forEach((pool) => {
 			pool.vdevs.forEach((vDev) => {
 				vDev.disks.forEach((usedDisk) => {
 					// console.log('disk from vdev:', usedDisk);
-					const cleanedUsedDiskPath = cleanDiskPath(usedDisk.path);
+					const cleanedUsedDiskPath = normalizeDiskPath(usedDisk.path);
 					const selectedDisk = matchDiskByVdevOrPath(disks, cleanedUsedDiskPath);
 					let statsObject;
 
@@ -519,7 +490,7 @@ export async function loadDisksExtraData(disks, pools) {
 						// Clean the usedDisk.path and compare it with sd_path, phy_path, and vdev_path
 						// Find the index of the original disk in the disks array
 						const index = disks.findIndex(disk =>
-							[cleanDiskPath(disk.sd_path), cleanDiskPath(disk.phy_path), cleanDiskPath(disk.vdev_path)].includes(cleanedUsedDiskPath)
+							[normalizeDiskPath(disk.sd_path), normalizeDiskPath(disk.phy_path), normalizeDiskPath(disk.vdev_path)].includes(cleanedUsedDiskPath)
 						);
 
 						// Check if the original disk is found in the disks array
@@ -710,7 +681,7 @@ export function parseVDevData(vDev, poolName, disks, vDevType) {
 					if (result) {
 						const fullOldDisk = disks.value.find(d => d.name === oldDisk.name);
 						const shortSdPath = fullOldDisk?.sd_path?.replace(sdPathPrefix, "") ?? "";
-						result.replacingTargetLabel = `${oldDisk.name} (${cleanDiskPath(shortSdPath)})`;
+						result.replacingTargetLabel = `${oldDisk.name} (${normalizeDiskPath(shortSdPath)})`;
 
 						if (!vDevData.disks.some(d => d.guid === result.guid || d.path === result.path || d.name === result.name)) {
 							vDevData.disks.push(result);
@@ -747,41 +718,20 @@ function handleDiskChild(child, vDevData, disks, vDevName, poolName, vDevType) {
 		return null;
 	}
 
-	const cleanedChildPath = cleanDiskPath(child.path);
-
-	// exact match on base device paths only
-	let fullDiskData = disks.value.find(disk => {
-		const sdBase = cleanDiskPath(disk.sd_path);
-		const phyBase = cleanDiskPath(disk.phy_path);
-		const vdevBase = cleanDiskPath(disk.vdev_path);
-		const pathBase = cleanDiskPath(disk.path);
-		const idBase = cleanDiskPath(disk.id_path);
-		const labelBase = cleanDiskPath(disk.label_path);
-		const partLabelBase = cleanDiskPath(disk.part_label_path);
-
-		return (
-			sdBase === cleanedChildPath ||
-			phyBase === cleanedChildPath ||
-			vdevBase === cleanedChildPath ||
-			pathBase === cleanedChildPath ||
-			idBase === cleanedChildPath ||
-			labelBase === cleanedChildPath ||
-			partLabelBase === cleanedChildPath
+	const cleanedChildPath = normalizeDiskPath(child.path);
+	const matchesPath = (disk: any, target: string) =>
+		getDiskPathCandidates(disk).some(
+			(path) => normalizeDiskPath(path) === target,
 		);
-	});
+
+	let fullDiskData = disks.value.find((disk) =>
+		matchesPath(disk, cleanedChildPath),
+	);
 
 	// If fullDiskData is still null (child has a valid path), try to recover it
 	if (!fullDiskData) {
-		// 1) If the child path is a by-vdev partition, match its base by-vdev
 		const vdevBase = cleanedChildPath.replace(/-part\d+$/, '');
-		fullDiskData = disks.value.find(d =>
-			cleanDiskPath(d.vdev_path) === vdevBase ||
-			cleanDiskPath(d.sd_path) === vdevBase ||
-			cleanDiskPath(d.phy_path) === vdevBase ||
-			cleanDiskPath(d.id_path) === vdevBase ||
-			cleanDiskPath(d.label_path) === vdevBase ||
-			cleanDiskPath(d.part_label_path) === vdevBase
-		);
+		fullDiskData = disks.value.find((disk) => matchesPath(disk, vdevBase));
 
 		if (fullDiskData) {
 			console.warn(`Recovered disk via safety net using ${vdevBase}`);
@@ -857,9 +807,9 @@ function handleDiskChild(child, vDevData, disks, vDevName, poolName, vDevType) {
 	if (!fullDiskData) {
 		console.warn('No match for', child.path);
 	} else {
-		const exp = cleanDiskPath(child.path);
+		const exp = normalizeDiskPath(child.path);
 		const candidatePaths = [fullDiskData.vdev_path, fullDiskData.sd_path, fullDiskData.phy_path]
-			.map(p => cleanDiskPath(p))
+			.map(p => normalizeDiskPath(p))
 			.filter(p => p && p !== 'N/A' && p !== 'unknown');
 		if (candidatePaths.length > 0 && !candidatePaths.includes(exp)) {
 			console.warn('Mismatch:', { child: exp, matched: candidatePaths, matchedName: fullDiskData.name });
@@ -1032,7 +982,7 @@ function determineDiskType(vDev, disks): string {
 		// Try name match first, then path-based match via matchDiskByVdevOrPath
 		let disk = disks.value.find(d => d.name === child.name);
 		if (!disk && child.path) {
-			disk = matchDiskByVdevOrPath(disks, cleanDiskPath(child.path));
+			disk = matchDiskByVdevOrPath(disks, normalizeDiskPath(child.path));
 		}
 		return disk ? disk.type : 'Unknown';
 	});

--- a/zfs/src/composables/loadData.ts
+++ b/zfs/src/composables/loadData.ts
@@ -487,11 +487,9 @@ export async function loadDisksExtraData(disks, pools) {
 						selectedDisk.stats = statsObject;
 						// console.log('selectedDisk loading data', selectedDisk);
 
-						// Clean the usedDisk.path and compare it with sd_path, phy_path, and vdev_path
-						// Find the index of the original disk in the disks array
-						const index = disks.findIndex(disk =>
-							[normalizeDiskPath(disk.sd_path), normalizeDiskPath(disk.phy_path), normalizeDiskPath(disk.vdev_path)].includes(cleanedUsedDiskPath)
-						);
+						// matchDiskByVdevOrPath returns the original object from this array,
+						// including when it matched through an alternate by-id alias.
+						const index = disks.indexOf(selectedDisk);
 
 						// Check if the original disk is found in the disks array
 						if (index !== -1) {

--- a/zfs/src/scripts/get-disks.py
+++ b/zfs/src/scripts/get-disks.py
@@ -415,9 +415,10 @@ def _udev_alias_paths(base: str) -> dict:
             if line.startswith("DEVLINKS="):
                 devlinks_str = line.split("=", 1)[1].strip()
                 break
+        by_id_paths = []
         for p in devlinks_str.split():
-            if p.startswith("/dev/disk/by-id/") and "id_path" not in out:
-                out["id_path"] = p
+            if p.startswith("/dev/disk/by-id/"):
+                by_id_paths.append(p)
             elif p.startswith("/dev/disk/by-label/") and "label_path" not in out:
                 out["label_path"] = p
             elif p.startswith("/dev/disk/by-partlabel/") and "part_label_path" not in out:
@@ -426,6 +427,14 @@ def _udev_alias_paths(base: str) -> dict:
                 out["part_uuid"] = p
             elif p.startswith("/dev/disk/by-uuid/") and "uuid" not in out:
                 out["uuid"] = p
+
+        if by_id_paths:
+            ordered = sorted(set(by_id_paths))
+            out["id_paths"] = ordered
+            out["id_path"] = next(
+                (p for p in ordered if Path(p).name.startswith("ata-")),
+                ordered[0],
+            )
     except Exception:
         pass
     return out

--- a/zfs/tests/python/test_get_disks.py
+++ b/zfs/tests/python/test_get_disks.py
@@ -1,0 +1,33 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "src" / "scripts" / "get-disks.py"
+SPEC = importlib.util.spec_from_file_location("cockpit_zfs_get_disks", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class UdevAliasPathsTests(unittest.TestCase):
+    def test_preserves_all_by_id_aliases_and_prefers_ata_for_legacy_field(self):
+        ata = "/dev/disk/by-id/ata-MODEL_SERIAL_A"
+        wwn = "/dev/disk/by-id/wwn-0x5000000000000001"
+        result = SimpleNamespace(
+            returncode=0,
+            stdout=f"DEVLINKS={wwn} {ata} /dev/disk/by-diskseq/12\n",
+            stderr="",
+        )
+
+        with patch.object(MODULE.subprocess, "run", return_value=result):
+            aliases = MODULE._udev_alias_paths("/dev/sdd")
+
+        self.assertEqual(aliases["id_paths"], [ata, wwn])
+        self.assertEqual(aliases["id_path"], ata)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zfs/tests/unit/helpers.test.ts
+++ b/zfs/tests/unit/helpers.test.ts
@@ -5,6 +5,7 @@ vi.mock("@45drives/houston-common-lib", () => ({ legacy: {} }));
 import {
   convertTimestampToLocal,
   matchDiskByVdevOrPath,
+  normalizeScanProgress,
 } from "../../src/composables/helpers";
 
 describe("matchDiskByVdevOrPath", () => {
@@ -43,4 +44,39 @@ describe("convertTimestampToLocal", () => {
     "returns N/A for invalid input %p",
     (value) => expect(convertTimestampToLocal(value as any)).toBe("N/A"),
   );
+});
+
+describe("normalizeScanProgress", () => {
+  it("renders the observed finished scrub as 100 percent with equal counters", () => {
+    expect(normalizeScanProgress({
+      state: "FINISHED",
+      percentage: 89.44723606109619,
+      bytes_to_process: 7_335_936,
+      bytes_processed: 7_335_936,
+      bytes_issued: 6_561_792,
+    })).toEqual({
+      percentage: 100,
+      processedBytes: 7_335_936,
+      totalBytes: 7_335_936,
+    });
+  });
+
+  it("uses processed and total counters for an active scrub", () => {
+    expect(normalizeScanProgress({
+      state: "SCANNING",
+      percentage: 37.5,
+      bytes_to_process: 800,
+      bytes_processed: 300,
+      bytes_issued: 250,
+    })).toEqual({ percentage: 37.5, processedBytes: 300, totalBytes: 800 });
+  });
+
+  it("clamps malformed percentage and counters", () => {
+    expect(normalizeScanProgress({
+      state: "SCANNING",
+      percentage: 140,
+      bytes_to_process: 100,
+      bytes_processed: 120,
+    })).toEqual({ percentage: 100, processedBytes: 100, totalBytes: 100 });
+  });
 });

--- a/zfs/tests/unit/helpers.test.ts
+++ b/zfs/tests/unit/helpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@45drives/houston-common-lib", () => ({ legacy: {} }));
+
+import { matchDiskByVdevOrPath } from "../../src/composables/helpers";
+
+describe("matchDiskByVdevOrPath", () => {
+  it("matches a partitioned ATA ZFS path through any equivalent by-id alias", () => {
+    const ata = "/dev/disk/by-id/ata-MODEL_SERIAL_A";
+    const disk = {
+      name: "sdd",
+      sd_path: "/dev/sdd",
+      phy_path: "/dev/disk/by-path/pci-0000:58:00.0-ata-2",
+      vdev_path: "N/A",
+      id_path: "/dev/disk/by-id/wwn-0x5000000000000001",
+      id_paths: [
+        "/dev/disk/by-id/wwn-0x5000000000000001",
+        ata,
+      ],
+    } as any;
+
+    expect(matchDiskByVdevOrPath([disk], `${ata}-part1`)).toBe(disk);
+  });
+});

--- a/zfs/tests/unit/helpers.test.ts
+++ b/zfs/tests/unit/helpers.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@45drives/houston-common-lib", () => ({ legacy: {} }));
 
-import { matchDiskByVdevOrPath } from "../../src/composables/helpers";
+import {
+  convertTimestampToLocal,
+  matchDiskByVdevOrPath,
+} from "../../src/composables/helpers";
 
 describe("matchDiskByVdevOrPath", () => {
   it("matches a partitioned ATA ZFS path through any equivalent by-id alias", () => {
@@ -21,4 +24,23 @@ describe("matchDiskByVdevOrPath", () => {
 
     expect(matchDiskByVdevOrPath([disk], `${ata}-part1`)).toBe(disk);
   });
+});
+
+describe("convertTimestampToLocal", () => {
+  it("treats a timezone-aware space-separated value like its ISO equivalent", () => {
+    expect(convertTimestampToLocal("2026-07-10 14:43:27+00:00")).toBe(
+      convertTimestampToLocal("2026-07-10T14:43:27Z"),
+    );
+  });
+
+  it("retains the existing UTC assumption for a naive scan timestamp", () => {
+    expect(convertTimestampToLocal("2026-07-10 14:43:27")).toBe(
+      convertTimestampToLocal("2026-07-10T14:43:27Z"),
+    );
+  });
+
+  it.each(["", "not-a-date", null, undefined])(
+    "returns N/A for invalid input %p",
+    (value) => expect(convertTimestampToLocal(value as any)).toBe("N/A"),
+  );
 });

--- a/zfs/tests/unit/loadData.test.ts
+++ b/zfs/tests/unit/loadData.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@45drives/houston-common-lib", () => ({ legacy: {} }));
+vi.mock("../../src/composables/pools", () => ({ getPools: vi.fn() }));
+vi.mock("../../src/composables/disks", () => ({ getDisks: vi.fn() }));
+vi.mock("../../src/composables/datasets", () => ({ getDatasets: vi.fn() }));
+vi.mock("../../src/composables/snapshots", () => ({
+  getSnapshots: vi.fn(),
+  getSnapshotsOfDataset: vi.fn(),
+  getSnapshotsOfPool: vi.fn(),
+}));
+vi.mock("../../src/composables/scan", () => ({
+  getDiskStats: vi.fn(),
+  getScanGroup: vi.fn(),
+}));
+
+import { loadDisksExtraData } from "../../src/composables/loadData";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadDisksExtraData", () => {
+  it("does not report a matched by-id alias as missing from the disk inventory", async () => {
+    const ata = "/dev/disk/by-id/ata-MODEL_SERIAL_A";
+    const wwn = "/dev/disk/by-id/wwn-0x5000000000000001";
+    const disk = {
+      name: "sda",
+      type: "HDD",
+      sd_path: "/dev/sda",
+      phy_path: "/dev/disk/by-path/pci-0000:58:00.0-ata-2",
+      vdev_path: "N/A",
+      id_path: ata,
+      id_paths: [ata, wwn],
+      path: "/dev/sda",
+      guid: "",
+      stats: {},
+    };
+    const usedDisk = {
+      path: `${wwn}-part1`,
+      guid: "12345",
+      stats: { readErrors: 0, writeErrors: 0, checksumErrors: 0 },
+    };
+    const pools = [{ vdevs: [{ stats: {}, disks: [usedDisk] }] }];
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await loadDisksExtraData([disk], pools);
+
+    expect(error).not.toHaveBeenCalledWith(
+      "Original disk not found in the disks array",
+    );
+    expect(disk).toMatchObject({
+      guid: usedDisk.guid,
+      path: usedDisk.path,
+      stats: usedDisk.stats,
+    });
+  });
+});

--- a/zfs/vitest.config.ts
+++ b/zfs/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config.js";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["tests/unit/**/*.test.ts"],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- Preserve every udev `/dev/disk/by-id` alias while retaining a deterministic legacy `id_path`.
- Match ZFS members against all equivalent disk paths, including partitioned aliases.
- Reuse the already-matched inventory object when merging vdev metadata so an alternate alias is not reported as a missing disk.
- Parse both naive and timezone-aware ZFS timestamps without producing invalid date strings.
- Normalize completed scan progress to 100% and use the processed/total byte counters consistently.
- Add deterministic Python and Vitest regressions for all three cases.

## Root cause

The disk inventory retained only the first udev by-id link, so ZFS could report an ATA alias while the inventory exposed a WWN alias (or vice versa). After a successful alias match, the metadata merge repeated a narrower path-only lookup and logged the same disk as missing. The timestamp formatter appended `Z` even when a timezone was already present. The scan UI displayed libzfs's raw percentage and paired `bytes_issued` with `bytes_processed`, which can remain inconsistent after a completed scan.

## User impact

Pool members now retain their disk metadata without false missing-disk diagnostics when ZFS and udev choose different aliases. Completed scrub/resilver information displays a valid local timestamp, 100% completion, and equal processed/total values without changing active-scan behavior.

## Validation

- `python3 -m unittest discover -s zfs/tests/python -p 'test_*.py' -v`
- `yarn --cwd zfs test` (11 tests)
- `python3 -m py_compile zfs/src/scripts/get-disks.py`
- `git diff --check`
- `AUTO_UPGRADE_DEPS=0 make` on Debian 13
- Checksum-verified staging in a disposable Debian 13 Cockpit VM with six virtual ZFS members, HTTP 200 route validation, and reboot-persistence verification

## AI assistance

This contribution was developed with AI assistance. I reviewed and tested all changes and take responsibility for the submitted code.
